### PR TITLE
fix: ArgumentOutOfRangeException when no hits

### DIFF
--- a/Assets/Editor/EditorSpotlight.cs
+++ b/Assets/Editor/EditorSpotlight.cs
@@ -318,6 +318,7 @@ public class EditorSpotlight : EditorWindow, IHasCustomMenu
     void OpenSelectedAssetAndClose()
     {
         Close();
+        if (hits.Count <= selectedIndex) return;
 
         AssetDatabase.OpenAsset(GetSelectedAsset());
 


### PR DESCRIPTION
ArgumentOutOfRangeException when no hits.
https://github.com/marijnz/unity-editor-spotlight/blob/master/Assets/Editor/EditorSpotlight.cs#L334