### PR TITLE
Fix UI glitch caused in EnforceWindowSize

### DIFF
--- a/Assets/Editor/EditorSpotlight.cs
+++ b/Assets/Editor/EditorSpotlight.cs
@@ -338,10 +338,13 @@ public class EditorSpotlight : EditorWindow, IHasCustomMenu
 
     public void EnforceWindowSize()
     {
-        var pos = position;
+        /* var pos = position;
         pos.width = 500;
         pos.height = BaseHeight;
-        position = pos;
+        position = pos; */
+
+        position.Set(position.x, position.y, 500, BaseHeight);
+
     }
 
     public void AddItemsToMenu(GenericMenu menu)

--- a/Assets/Editor/EditorSpotlight.cs
+++ b/Assets/Editor/EditorSpotlight.cs
@@ -31,6 +31,8 @@ public class EditorSpotlight : EditorWindow, IHasCustomMenu
                 focused = new GUIStyleState()
             };
 
+            inputFieldStyle.focused.textColor = Color.white;
+
             placeholderStyle = new GUIStyle(inputFieldStyle) {normal =
             {
                 textColor = EditorGUIUtility.isProSkin ? new Color(1, 1, 1, .2f) : new Color(.2f, .2f, .2f, .4f)


### PR DESCRIPTION
Window's UI that wanted to constantly be updated in `OnGUI`, used to be glitchy. It was caused by the code inside `EnforceWindowSize`. Using the `position.Set()` instead of copying `position` into a var and changing values of the var and rewriting it back to position, fixed this problem. Maybe it's because of sth internal in newer Unity editor versions.